### PR TITLE
Rails Blog App - Integration specs for views and fix N+1 problems.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -57,9 +57,11 @@ gem 'bootsnap', require: false
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
+  gem 'capybara'
   gem 'debug', platforms: %i[mri mingw x64_mingw]
   gem 'rails-controller-testing'
   gem 'rspec-rails'
+  gem 'webdrivers', '5.3.1'
 end
 
 group :development do
@@ -75,7 +77,6 @@ end
 
 group :test do
   # Use system testing [https://guides.rubyonrails.org/testing.html#system-testing]
-  gem 'capybara'
+  gem 'database_cleaner'
   gem 'selenium-webdriver'
-  gem 'webdrivers'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -85,6 +85,12 @@ GEM
       xpath (~> 3.2)
     concurrent-ruby (1.2.2)
     crass (1.0.6)
+    database_cleaner (2.0.2)
+      database_cleaner-active_record (>= 2, < 3)
+    database_cleaner-active_record (2.1.0)
+      activerecord (>= 5.a)
+      database_cleaner-core (~> 2.0.0)
+    database_cleaner-core (2.0.1)
     date (3.3.3)
     debug (1.8.0)
       irb (>= 1.5.0)
@@ -267,6 +273,7 @@ PLATFORMS
 DEPENDENCIES
   bootsnap
   capybara
+  database_cleaner
   debug
   dotenv-rails
   importmap-rails
@@ -283,7 +290,7 @@ DEPENDENCIES
   turbo-rails
   tzinfo-data
   web-console
-  webdrivers
+  webdrivers (= 5.3.1)
   will_paginate
 
 RUBY VERSION

--- a/README.md
+++ b/README.md
@@ -120,6 +120,11 @@ To run tests, run the following command:
 - GitHub: [@mailsg](https://github.com/mailsg)
 - LinkedIn: [LinkedIn](https://linkedin.com/in/sandeep0912/)
 
+👤 **Alijan Rahimi**
+
+- GitHub: [@rahimialijan](https://github.com/rahimialijan)
+- LinkedIn: [LinkedIn](https://linkedin.com/in/alijan-rahimi-18389ab3/)
+
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
 
 <!-- FUTURE FEATURES -->

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,11 +1,11 @@
 class PostsController < ApplicationController
   def index
     @user = User.find(params[:user_id])
-    @posts = @user.posts.paginate(page: params[:page], per_page: 2)
+    @posts = @user.posts.includes(:comments).paginate(page: params[:page], per_page: 2)
   end
 
   def show
-    @post = Post.find(params[:id])
+    @post = Post.includes(comments: :author).find(params[:id])
     @current = current_user
     @comment = Comment.new
     @comments = @post.comments

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -15,7 +15,7 @@
     <a href ="<%= user_post_path(@user, post)%>"><%= render post%></a>
     <%= "no comments for this post" if post.comments.empty?%>
     <div class="comments">
-    <% post.five_most_recent_comments.each do |comment|%>
+    <% post.five_most_recent_comments.includes(:author).each do |comment|%>
         <%=render comment%>
     <% end %>
     </div>

--- a/spec/integration/posts/post_index_spec.rb
+++ b/spec/integration/posts/post_index_spec.rb
@@ -1,0 +1,1 @@
+require 'rails_helper'

--- a/spec/integration/posts/post_index_spec.rb
+++ b/spec/integration/posts/post_index_spec.rb
@@ -1,1 +1,86 @@
 require 'rails_helper'
+
+RSpec.describe 'post index view page', type: :system do
+  let!(:user1) do
+    User.create(
+      name: 'test user1',
+      photo: 'https://images.example.com/i/086/5621234.jpg',
+      bio: 'test_bio1',
+      posts_counter: 1
+    )
+  end
+
+  let!(:post1) do
+    Post.create(author: user1, title: 'Post 1', text: 'Post 1 content', comments_counter: 1, likes_counter: 0)
+  end
+  let!(:post2) do
+    Post.create(author: user1, title: 'Post 2', text: 'Post 2 content', comments_counter: 1, likes_counter: 0)
+  end
+
+  let!(:comment1) do
+    Comment.create(post: post1, author: user1, text: 'nice!')
+  end
+  let!(:comment2) do
+    Comment.create(post: post1, author: user1, text: 'nice!')
+  end
+  let!(:comment2) do
+    Comment.create(post: post1, author: user1, text: 'nice!')
+  end
+  let!(:comment2) do
+    Comment.create(post: post1, author: user1, text: 'nice!')
+  end
+  let!(:comment2) do
+    Comment.create(post: post1, author: user1, text: 'nice!')
+  end
+
+  describe 'show correct posts for user1' do
+    before(:example) do
+      visit user_posts_path(user1)
+    end
+
+    it 'displays the user\'s profile picture' do
+      expect(page).to have_selector("img[src='#{user1.photo}']")
+    end
+
+    it 'displays the user\'s username' do
+      expect(page).to have_content(user1.name)
+    end
+
+    it 'displays the number of posts the user has written' do
+      expect(page).to have_content("Number of posts: #{user1.posts_counter}")
+    end
+
+    it 'displays a post\'s title and text' do
+      expect(page).to have_content(post1.title)
+      expect(page).to have_content(post1.text)
+      expect(page).to have_content(post2.title)
+      expect(page).to have_content(post2.text)
+    end
+
+    it 'displays the first comments on a post' do
+      expect(page).to have_content(comment1.text)
+    end
+
+    it 'displays the number of comments a post has' do
+      expect(page).to have_content("comments: #{post1.comments_counter}")
+    end
+
+    it 'displays the number of likes a post has' do
+      expect(page).to have_content("Likes: #{post1.likes_counter}")
+    end
+
+    it 'redirects to the post show page when a post is clicked' do
+      click_link post1.title
+      expect(page).to have_current_path(user_post_path(user1, post1))
+      expect(page).to have_content(post1.title)
+    end
+
+    it 'displays a section for pagination if there are more posts' do
+      # Set the user's posts_counter to a value that exceeds the page limit
+      user1.update(posts_counter: 10)
+
+      visit user_path(user1)
+      expect(page).to have_selector('.button-container')
+    end
+  end
+end

--- a/spec/integration/posts/post_show_spec.rb
+++ b/spec/integration/posts/post_show_spec.rb
@@ -1,0 +1,1 @@
+require 'rails_helper'

--- a/spec/integration/posts/post_show_spec.rb
+++ b/spec/integration/posts/post_show_spec.rb
@@ -1,1 +1,68 @@
 require 'rails_helper'
+
+RSpec.describe 'post index view page', type: :system do
+  let!(:user1) do
+    User.create(
+      name: 'test user1',
+      photo: 'https://images.example.com/i/086/5621234.jpg',
+      bio: 'test_bio1',
+      posts_counter: 1
+    )
+  end
+
+  let!(:post1) do
+    Post.create(author: user1, title: 'Post 1', text: 'Post 1 content', comments_counter: 1, likes_counter: 0)
+  end
+
+  let!(:comment1) do
+    Comment.create(post: post1, author: user1, text: 'nice!')
+  end
+  let!(:comment2) do
+    Comment.create(post: post1, author: user1, text: 'nice!')
+  end
+  let!(:comment2) do
+    Comment.create(post: post1, author: user1, text: 'nice!')
+  end
+  let!(:comment2) do
+    Comment.create(post: post1, author: user1, text: 'nice!')
+  end
+  let!(:comment2) do
+    Comment.create(post: post1, author: user1, text: 'nice!')
+  end
+
+  describe 'show correct post for user1' do
+    before(:example) do
+      visit user_post_path(user1, post1)
+    end
+
+    it 'displays the post title' do
+      expect(page).to have_content(post1.title)
+    end
+
+    it 'displays the post author' do
+      expect(page).to have_content(user1.name)
+    end
+
+    it 'displays the number of comments' do
+      expect(page).to have_content("comments: #{post1.comments_counter}")
+    end
+
+    it 'displays the number of likes' do
+      expect(page).to have_content("Likes: #{post1.likes_counter}")
+    end
+
+    it 'displays the post body' do
+      expect(page).to have_content(post1.text)
+    end
+
+    it 'displays the username of each commenter' do
+      expect(page).to have_content(comment1.author.name)
+      expect(page).to have_content(comment2.author.name)
+    end
+
+    it 'displays the comment left by each commenter' do
+      expect(page).to have_content(comment1.text)
+      expect(page).to have_content(comment2.text)
+    end
+  end
+end

--- a/spec/integration/users/user_index_spec.rb
+++ b/spec/integration/users/user_index_spec.rb
@@ -1,0 +1,1 @@
+require 'rails_helper'

--- a/spec/integration/users/user_index_spec.rb
+++ b/spec/integration/users/user_index_spec.rb
@@ -1,1 +1,51 @@
 require 'rails_helper'
+
+RSpec.describe 'user show view page', type: :system do
+  let!(:user1) do
+    User.create(
+      name: 'test user1',
+      photo: 'https://images3.alphacoders.com/690/690494.jpg',
+      bio: 'test_bio1',
+      posts_counter: 1
+    )
+  end
+
+  let!(:posts) do
+    [
+      Post.create(author: user1, title: 'Post 1', text: 'Post 1 content', comments_counter: 1, likes_counter: 1),
+      Post.create(author: user1, title: 'Post 2', text: 'Post 2 content', comments_counter: 2, likes_counter: 2),
+      Post.create(author: user1, title: 'Post 3', text: 'Post 3 content', comments_counter: 3, likes_counter: 3)
+    ]
+  end
+
+  describe 'show user and post details' do
+    before(:example) do
+      visit user_path(user1)
+    end
+
+    it 'displays user information' do
+      expect(page).to have_content(user1.name)
+      expect(page).to have_content(user1.posts_counter)
+      expect(page).to have_content(user1.bio)
+      expect(page).to have_selector("img[src='#{user1.photo}']")
+    end
+
+    it 'displays user\'s first 3 posts' do
+      posts.take(3).each do |post|
+        expect(page).to have_content(post.title)
+        expect(page).to have_content(post.text)
+      end
+    end
+
+    it 'go to post show page when clicking a post' do
+      user_links = all("a[href='#{user_post_path(user1, posts.first)}']")
+      user_links.first.click
+      expect(page).to have_current_path(user_post_path(user1, posts.first))
+    end
+
+    it 'redirects to user\'s posts index page when clicking to see all posts' do
+      click_link 'See all posts'
+      expect(page).to have_current_path(user_posts_path(user1))
+    end
+  end
+end

--- a/spec/integration/users/user_index_spec.rb
+++ b/spec/integration/users/user_index_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe 'user index view page', type: :system do
   let!(:user1) do
     User.create(
       name: 'test user1',
-      photo: 'https://images3.alphacoders.com/690/690494.jpg',
+      photo: 'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcRrkfBY9UTdiEHSYCSo7iuM4k1Eyv-u9YwGqQ&usqp=CAU',
       bio: 'test_bio1',
       posts_counter: 1
     )
@@ -13,7 +13,7 @@ RSpec.describe 'user index view page', type: :system do
   let!(:user2) do
     User.create(
       name: 'test user2',
-      photo: 'https://images.pexels.com/photos/2913125/pexels-photo-2913125.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=2',
+      photo: 'https://lumiere-a.akamaihd.net/v1/images/ct_cinderella_upcportalreskin_20694_f7c876a1.jpeg?region=0,0,330,330',
       bio: 'test_bio2',
       posts_counter: 2
     )
@@ -22,7 +22,7 @@ RSpec.describe 'user index view page', type: :system do
   let!(:user3) do
     User.create(
       name: 'test user3',
-      photo: 'https://static.photocdn.pt/images/articles/2018/12/05/articles/2017_8/beginner_photography_mistakes-1.webp',
+      photo: 'https://www.rd.com/wp-content/uploads/2020/11/RD-mickey-mouse-GettyImages-1137134597-JVcrop.jpg',
       bio: 'test_bio3',
       posts_counter: 0
     )
@@ -40,9 +40,9 @@ RSpec.describe 'user index view page', type: :system do
     end
 
     it ' can see profile picture' do
-      expect(page).to have_selector('img#user-image[src="https://images3.alphacoders.com/690/690494.jpg"]')
-      expect(page).to have_selector('img#user-image[src="https://images.pexels.com/photos/2913125/pexels-photo-2913125.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=2"]')
-      expect(page).to have_selector('img#user-image[src="https://static.photocdn.pt/images/articles/2018/12/05/articles/2017_8/beginner_photography_mistakes-1.webp"]')
+      expect(page).to have_selector('img#user-image[src="https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcRrkfBY9UTdiEHSYCSo7iuM4k1Eyv-u9YwGqQ&usqp=CAU"]')
+      expect(page).to have_selector('img#user-image[src="https://lumiere-a.akamaihd.net/v1/images/ct_cinderella_upcportalreskin_20694_f7c876a1.jpeg?region=0,0,330,330"]')
+      expect(page).to have_selector('img#user-image[src="https://www.rd.com/wp-content/uploads/2020/11/RD-mickey-mouse-GettyImages-1137134597-JVcrop.jpg"]')
     end
 
     it 'can see posts count' do

--- a/spec/integration/users/user_index_spec.rb
+++ b/spec/integration/users/user_index_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe 'user show view page', type: :system do
+RSpec.describe 'user index view page', type: :system do
   let!(:user1) do
     User.create(
       name: 'test user1',
@@ -10,42 +10,59 @@ RSpec.describe 'user show view page', type: :system do
     )
   end
 
-  let!(:posts) do
-    [
-      Post.create(author: user1, title: 'Post 1', text: 'Post 1 content', comments_counter: 1, likes_counter: 1),
-      Post.create(author: user1, title: 'Post 2', text: 'Post 2 content', comments_counter: 2, likes_counter: 2),
-      Post.create(author: user1, title: 'Post 3', text: 'Post 3 content', comments_counter: 3, likes_counter: 3)
-    ]
+  let!(:user2) do
+    User.create(
+      name: 'test user2',
+      photo: 'https://images.pexels.com/photos/2913125/pexels-photo-2913125.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=2',
+      bio: 'test_bio2',
+      posts_counter: 2
+    )
   end
 
-  describe 'show user and post details' do
+  let!(:user3) do
+    User.create(
+      name: 'test user3',
+      photo: 'https://static.photocdn.pt/images/articles/2018/12/05/articles/2017_8/beginner_photography_mistakes-1.webp',
+      bio: 'test_bio3',
+      posts_counter: 0
+    )
+  end
+
+  describe 'user content' do
     before(:example) do
-      visit user_path(user1)
+      visit users_path
     end
 
-    it 'displays user information' do
+    it 'can see all users names' do
       expect(page).to have_content(user1.name)
-      expect(page).to have_content(user1.posts_counter)
+      expect(page).to have_content(user2.name)
+      expect(page).to have_content(user3.name)
+    end
+
+    it ' can see profile picture' do
+      expect(page).to have_selector('img#user-image[src="https://images3.alphacoders.com/690/690494.jpg"]')
+      expect(page).to have_selector('img#user-image[src="https://images.pexels.com/photos/2913125/pexels-photo-2913125.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=2"]')
+      expect(page).to have_selector('img#user-image[src="https://static.photocdn.pt/images/articles/2018/12/05/articles/2017_8/beginner_photography_mistakes-1.webp"]')
+    end
+
+    it 'can see posts count' do
+      expect(page).to have_content('Number of posts: 1')
+      expect(page).to have_content('Number of posts: 2')
+      expect(page).to have_content('Number of posts: 0')
+    end
+  end
+
+  describe 'click on a user' do
+    before(:example) do
+      visit users_path
+    end
+
+    it 'redirects to user show page when clicking on user name' do
+      user_link = find("a[href='#{user_path(user1)}']")
+      user_link.click
+      expect(page).to have_current_path(user_path(user1))
+      expect(page).to have_content(user1.name)
       expect(page).to have_content(user1.bio)
-      expect(page).to have_selector("img[src='#{user1.photo}']")
-    end
-
-    it 'displays user\'s first 3 posts' do
-      posts.take(3).each do |post|
-        expect(page).to have_content(post.title)
-        expect(page).to have_content(post.text)
-      end
-    end
-
-    it 'go to post show page when clicking a post' do
-      user_links = all("a[href='#{user_post_path(user1, posts.first)}']")
-      user_links.first.click
-      expect(page).to have_current_path(user_post_path(user1, posts.first))
-    end
-
-    it 'redirects to user\'s posts index page when clicking to see all posts' do
-      click_link 'See all posts'
-      expect(page).to have_current_path(user_posts_path(user1))
     end
   end
 end

--- a/spec/integration/users/user_show_spec.rb
+++ b/spec/integration/users/user_show_spec.rb
@@ -1,0 +1,1 @@
+require 'rails_helper'

--- a/spec/integration/users/user_show_spec.rb
+++ b/spec/integration/users/user_show_spec.rb
@@ -1,1 +1,51 @@
 require 'rails_helper'
+
+RSpec.describe 'user show view page', type: :system do
+  let!(:user1) do
+    User.create(
+      name: 'test user1',
+      photo: 'https://images3.alphacoders.com/690/690494.jpg',
+      bio: 'test_bio1',
+      posts_counter: 1
+    )
+  end
+
+  let!(:posts) do
+    [
+      Post.create(author: user1, title: 'Post 1', text: 'Post 1 content', comments_counter: 1, likes_counter: 1),
+      Post.create(author: user1, title: 'Post 2', text: 'Post 2 content', comments_counter: 2, likes_counter: 2),
+      Post.create(author: user1, title: 'Post 3', text: 'Post 3 content', comments_counter: 3, likes_counter: 3)
+    ]
+  end
+
+  describe 'show user and post details' do
+    before(:example) do
+      visit user_path(user1)
+    end
+
+    it 'displays user information' do
+      expect(page).to have_content(user1.name)
+      expect(page).to have_content(user1.posts_counter)
+      expect(page).to have_content(user1.bio)
+      expect(page).to have_selector("img[src='#{user1.photo}']")
+    end
+
+    it 'displays user\'s first 3 posts' do
+      posts.take(3).each do |post|
+        expect(page).to have_content(post.title)
+        expect(page).to have_content(post.text)
+      end
+    end
+
+    it 'go to post show page when clicking a post' do
+      user_links = all("a[href='#{user_post_path(user1, posts.first)}']")
+      user_links.first.click
+      expect(page).to have_current_path(user_post_path(user1, posts.first))
+    end
+
+    it 'redirects to user\'s posts index page when clicking to see all posts' do
+      click_link 'See all posts'
+      expect(page).to have_current_path(user_posts_path(user1))
+    end
+  end
+end

--- a/spec/integration/users/user_show_spec.rb
+++ b/spec/integration/users/user_show_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe 'user show view page', type: :system do
   let!(:user1) do
     User.create(
       name: 'test user1',
-      photo: 'https://images3.alphacoders.com/690/690494.jpg',
+      photo: 'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcRrkfBY9UTdiEHSYCSo7iuM4k1Eyv-u9YwGqQ&usqp=CAU',
       bio: 'test_bio1',
       posts_counter: 1
     )

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,5 +1,7 @@
 # This file is copied to spec/ when you run 'rails generate rspec:install'
 require 'spec_helper'
+require 'capybara/rspec'
+require 'database_cleaner'
 ENV['RAILS_ENV'] ||= 'test'
 require_relative '../config/environment'
 # Prevent database truncation if the environment is production
@@ -60,4 +62,13 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
+  config.before(:suite) do
+    DatabaseCleaner.strategy = :truncation
+  end
+
+  config.before(:each) do
+    DatabaseCleaner.clean
+  end
 end
+
+Capybara.default_driver = :selenium_chrome

--- a/spec/requests/posts_spec.rb
+++ b/spec/requests/posts_spec.rb
@@ -2,14 +2,14 @@ require 'rails_helper'
 
 RSpec.describe 'Posts', type: :request do
   describe 'GET /index', type: :request do
-    let!(:user) do 
+    let!(:user) do
       User.create(
         name: 'test user',
         photo: 'https://example.com/photos/0X8086XX09',
         bio: 'test_bio',
         posts_counter: 1
       )
-  end
+    end
 
     before(:example) { get "/users/#{user.id}/posts" }
 
@@ -27,7 +27,7 @@ RSpec.describe 'Posts', type: :request do
   end
 
   describe 'GET /show', type: :request do
-    let!(:user) do 
+    let!(:user) do
       User.create(
         name: 'test user',
         photo: 'https://example.com/photos/0X8086XX09',
@@ -36,7 +36,7 @@ RSpec.describe 'Posts', type: :request do
       )
     end
 
-    let!(:post) do 
+    let!(:post) do
       Post.create(
         author: user,
         title: 'Hello',

--- a/spec/requests/posts_spec.rb
+++ b/spec/requests/posts_spec.rb
@@ -2,12 +2,14 @@ require 'rails_helper'
 
 RSpec.describe 'Posts', type: :request do
   describe 'GET /index', type: :request do
-    user = User.create(
-      name: 'test user',
-      photo: 'https://example.com/photos/0X8086XX09',
-      bio: 'test_bio',
-      posts_counter: 1
-    )
+    let!(:user) do 
+      User.create(
+        name: 'test user',
+        photo: 'https://example.com/photos/0X8086XX09',
+        bio: 'test_bio',
+        posts_counter: 1
+      )
+  end
 
     before(:example) { get "/users/#{user.id}/posts" }
 
@@ -20,25 +22,29 @@ RSpec.describe 'Posts', type: :request do
     end
 
     it 'includes correct placeholder text in the response body' do
-      expect(response.body).to include('Here is a list of posts for a given user')
+      expect(response.body).to include('test user')
     end
   end
 
   describe 'GET /show', type: :request do
-    user = User.create(
-      name: 'test user',
-      photo: 'https://example.com/photos/0X8086XX09',
-      bio: 'test_bio',
-      posts_counter: 1
-    )
+    let!(:user) do 
+      User.create(
+        name: 'test user',
+        photo: 'https://example.com/photos/0X8086XX09',
+        bio: 'test_bio',
+        posts_counter: 1
+      )
+    end
 
-    post = Post.create(
-      author: user,
-      title: 'Hello',
-      text: 'This is my first post',
-      comments_counter: 1,
-      likes_counter: 1
-    )
+    let!(:post) do 
+      Post.create(
+        author: user,
+        title: 'Hello',
+        text: 'This is my first post',
+        comments_counter: 1,
+        likes_counter: 1
+      )
+    end
 
     before(:example) do
       get "/users/#{user.id}/posts/#{post.id}"
@@ -53,7 +59,7 @@ RSpec.describe 'Posts', type: :request do
     end
 
     it 'includes correct placeholder text in the response body' do
-      expect(response.body).to include('Here is a list of posts for a given user')
+      expect(response.body).to include(post.text)
     end
   end
 end

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -1,6 +1,14 @@
 require 'rails_helper'
 
 RSpec.describe 'users', type: :request do
+  let!(:user) do
+    User.create(
+      name: 'test user1',
+      photo: 'https://example.com/default-photo.jpg',
+      bio: 'test_bio',
+      posts_counter: 2
+    )
+  end
   describe 'GET /index', type: :request do
     before(:example) { get '/users' }
 
@@ -13,16 +21,18 @@ RSpec.describe 'users', type: :request do
     end
 
     it 'includes correct placeholder text in the response body' do
-      expect(response.body).to include('User')
+      expect(response.body).to include('Number of posts: 2')
     end
   end
   describe 'GET /show', type: :request do
-    user = User.create(
-      name: 'test user',
-      photo: 'https://example.com/photos/0X8086XX09',
-      bio: 'test_bio',
-      posts_counter: 1
-    )
+    let!(:user) do 
+      User.create(
+        name: 'test user',
+        photo: 'https://example.com/photos/0X8086XX09',
+        bio: 'test_bio',
+        posts_counter: 1
+      )
+    end
     before(:example) { get "/users/#{user.id}" }
 
     it 'displays the user details for a given user' do
@@ -34,7 +44,7 @@ RSpec.describe 'users', type: :request do
     end
 
     it 'includes correct placeholder text in the response body' do
-      expect(response.body).to include('User')
+      expect(response.body).to include('test user1')
     end
   end
 end

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe 'users', type: :request do
     end
 
     it 'includes correct placeholder text in the response body' do
-      expect(response.body).to include('test user1')
+      expect(response.body).to include('test user')
     end
   end
 end

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe 'users', type: :request do
     end
   end
   describe 'GET /show', type: :request do
-    let!(:user) do 
+    let!(:user) do
       User.create(
         name: 'test user',
         photo: 'https://example.com/photos/0X8086XX09',


### PR DESCRIPTION
Hi,

This PR is raised to showcase the implementation of Integration Specs. Below are the pointers covered:

- **Before fixing the `N+1` issue** - In the **Post index** page

![SS_1](https://github.com/mailsg/rails-blog-app/assets/105475440/cdabbece-e4bc-4f03-b384-4ee6e74c3dba)

- **Before fixing the `N+1` issue** - In the **Post show** page
 
![SS_2](https://github.com/mailsg/rails-blog-app/assets/105475440/a9e61a2f-b697-4972-baac-f22fdcd84b56)

- **After fixing the `N+1` issue** - In the **Post index** page

![SS_3](https://github.com/mailsg/rails-blog-app/assets/105475440/ccb4a687-e1df-4a05-ab24-17855409b652)

- **After fixing the `N+1` issue** - In the **Post show** page

![SS_4](https://github.com/mailsg/rails-blog-app/assets/105475440/e4034bd4-29e0-4f6c-90c1-a9761935c6de)


- Used `Capybara` to write integration tests for each view in the project.
- User index page:
  - I can see the username of all other users.
  - I can see the profile picture for each user.
  - I can see the number of posts each user has written.
  - When I click on a user, I am redirected to that user's show page.

- User show page:
  - I can see the user's profile picture.
  - I can see the user's username.
  - I can see the number of posts the user has written.
  - I can see the user's bio.
  - I can see the user's first 3 posts.
  - I can see a button that lets me view all of a user's posts.
  - When I click a user's post, it redirects me to that post's show page.
  - When I click to see all posts, it redirects me to the user's post's index page.

- User post index page:
  - I can see the user's profile picture.
  - I can see the user's username.
  - I can see the number of posts the user has written.
  - I can see a post's title.
  - I can see some of the post's body.
  - I can see the first comments on a post.
  - I can see how many comments a post has.
  - I can see how many likes a post has.
  - I can see a section for pagination if there are more posts than fit on the view.
  - When I click on a post, it redirects me to that post's show page.

- Post show page:
  - I can see the post's title.
  - I can see who wrote the post.
  - I can see how many comments it has.
  - I can see how many likes it has.
  - I can see the post body.
  - I can see the username of each commentor.
  - I can see the comment each commentor left.

![SS_5](https://github.com/mailsg/rails-blog-app/assets/105475440/175346b0-1d21-44b2-a28a-2f5ebd417ef1)


Kindly review the PR and provide feedback on the same.

Thanks.
